### PR TITLE
Fixed problem with logo centering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hangar-alpha",
   "description": "Share frontend assets between different web repositories",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "repository": {
     "type": "git",
     "url": "https://github.com/CartoDB/hangar-alpha.git"

--- a/src/scss/components/_navbar.scss
+++ b/src/scss/components/_navbar.scss
@@ -316,6 +316,13 @@
 
 //Navbar Logo
 
+.Navbar-header{
+  .Logo{
+    display: flex;
+    align-items: center;
+  }
+}
+
 .Navbar {
   .Logo--negative {
     display: flex;


### PR DESCRIPTION
Some times it's quite visible, so better if we always show the logo in the middle instead of top