### PR TITLE
Line height fix for is-subheader on mobile

### DIFF
--- a/src/scss/mixins/_titles.scss
+++ b/src/scss/mixins/_titles.scss
@@ -89,7 +89,7 @@
   line-height: 48px;
   @media (max-width: $layout-mobile) {
     font-size: 20px;
-    line-height: 24px;
+    line-height: 32px;
     &.is-subheader--mobile {
       @include is-subheader--mobile();
     }


### PR DESCRIPTION
Fixes: https://github.com/CartoDB/design/issues/1371